### PR TITLE
Update the gitignore to avoid including Blender backup files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ build/
 filesystem/
 *.z64
 .vscode/
+
+# Blender backup files
+*.blend1
+

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,5 @@ filesystem/
 .vscode/
 
 # Blender backup files
-*.blend1
+*.blend[0-9]
 


### PR DESCRIPTION
This change updates the `.gitignore`  to avoid including [Blender's backup files](https://blenderartists.org/t/blend-and-blend1/298461). 