### PR TITLE
Utilize `.d` files deeper in the build dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,9 +68,9 @@ $(FILESYSTEM_DIR)/%.xm64: $(ASSETS_DIR)/%.xm
 define MINIGAME_template
 SRC_$(1) = \
 	$$(wildcard $$(MINIGAME_DIR)/$(1)/*.c) \
-	$$(wildcard $$(MINIGAME_DIR)/$(1)/**/*.c) \
+	$$(wildcard $$(MINIGAME_DIR)/$(1)/*/*.c) \
 	$$(wildcard $$(MINIGAME_DIR)/$(1)/*.cpp) \
-	$$(wildcard $$(MINIGAME_DIR)/$(1)/**/*.cpp)
+	$$(wildcard $$(MINIGAME_DIR)/$(1)/*/*.cpp)
 $$(MINIGAMEDSO_DIR)/$(1).dso: $$(SRC_$(1):%.cpp=$$(BUILD_DIR)/%.o)
 $$(MINIGAMEDSO_DIR)/$(1).dso: $$(SRC_$(1):%.c=$$(BUILD_DIR)/%.o)
 -include $$(MINIGAME_DIR)/$(1)/$(1).mk
@@ -90,6 +90,6 @@ $(BUILD_DIR)/$(ROMNAME).msym: $(BUILD_DIR)/$(ROMNAME).elf
 clean:
 	rm -rf $(BUILD_DIR) $(FILESYSTEM_DIR) $(DSO_LIST) $(ROMNAME).z64 
 
--include $(wildcard $(BUILD_DIR)/*.d)
+-include $(wildcard $(BUILD_DIR)/*.d) $(wildcard $(BUILD_DIR)/*/*.d) $(wildcard $(BUILD_DIR)/*/*/*.d) $(wildcard $(BUILD_DIR)/*/*/*/*.d)
 
 .PHONY: all clean


### PR DESCRIPTION
Unfortunately make doesn't support glob `**`, so we need to provide different wildcards for `.d` files