### PR TITLE
Suppress unused warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,8 @@ ifeq ($(DEBUG), 1)
 	N64_CFLAGS += -g -O0
 	N64_LDFLAGS += -g
 else
-	N64_CFLAGS += -O2
+	N64_CFLAGS += -O2 -Wno-unused-but-set-variable -Wno-unused-variable -Wno-unused-function
+	N64_CXXFLAGS += -Wno-unused-but-set-variable -Wno-unused-variable -Wno-unused-function
 endif
 
 all: $(ROMNAME).z64


### PR DESCRIPTION
Instead of asking all the devs to add a bunch of  `__attribute__((unused))` or `#pragma GCC diagnostic ignored "-Wunused-..."`, just add compiler flags to ignore those warnings, for the final ROM of course