### PR TITLE
Changes to silence debug output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ ASSETS_LIST += $(subst $(ASSETS_DIR),$(FILESYSTEM_DIR),$(SOUND2_LIST:%.mp3=%.wav
 ASSETS_LIST += $(subst $(ASSETS_DIR),$(FILESYSTEM_DIR),$(MUSIC_LIST:%.xm=%.xm64))
 
 ifeq ($(DEBUG), 1)
-	N64_CFLAGS += -g -O0
+	N64_CFLAGS += -g -O0 -DDEBUG=$(DEBUG)
 	N64_LDFLAGS += -g
 else
 	N64_CFLAGS += -O2

--- a/code/64beats/64beats.c
+++ b/code/64beats/64beats.c
@@ -10,7 +10,9 @@ the game jam.
 #include "../../minigame.h"
 #include "64beats.h"
 
+#ifndef DEBUG
 #define DEBUG false
+#endif
 
 #define FONT_TEXT 1
 

--- a/code/furball/furball.c
+++ b/code/furball/furball.c
@@ -23,7 +23,9 @@ const MinigameDef minigame_def = {
 #define WIN_DELAY		5.0f
 #define WIN_SHOW_DELAY	2.0f
 
-#define DEBUG false;
+#ifndef DEBUG
+#define DEBUG false
+#endif
 
 #define FONT_TEXT           1
 #define TEXT_COLOR          0x6CBB3CFF

--- a/code/mallard/mallard.mk
+++ b/code/mallard/mallard.mk
@@ -37,9 +37,9 @@ ASSETS_LIST += \
 filesystem/mallard/HaloDekBig.font64: $(ASSETS_DIR)/mallard/HaloDekBig.ttf
 	@mkdir -p $(dir $@)
 	@echo "    [FONT] $@"
-	$(N64_MKFONT) $(MKFONT_FLAGS) --verbose --range 50-50 --range 41-41 --range 55-55 --range 53-53 --range 44-45 --range 2e-2e --size 60 --outline 1 -o $(dir $@) "$<"
+	$(N64_MKFONT) $(MKFONT_FLAGS) --range 50-50 --range 41-41 --range 55-55 --range 53-53 --range 44-45 --range 2e-2e --size 60 --outline 1 -o $(dir $@) "$<"
 
 filesystem/mallard/HaloDekMedium.font64: $(ASSETS_DIR)/mallard/HaloDekMedium.ttf
 	@mkdir -p $(dir $@)
 	@echo "    [FONT] $@"
-	$(N64_MKFONT) $(MKFONT_FLAGS) --verbose --range 30-39 --range 2e-2e --range 50-50 --range 20-20 --range 57-57 --range 49-49 --range 4E-4E --range 53-53 --range 44-44 --range 52-52 --range 41-41 --size 36 --outline 1 -o $(dir $@) "$<"
+	$(N64_MKFONT) $(MKFONT_FLAGS) --range 30-39 --range 2e-2e --range 50-50 --range 20-20 --range 57-57 --range 49-49 --range 4E-4E --range 53-53 --range 44-44 --range 52-52 --range 41-41 --size 36 --outline 1 -o $(dir $@) "$<"

--- a/code/sb_halcyon/physics/math/math_common.h
+++ b/code/sb_halcyon/physics/math/math_common.h
@@ -25,7 +25,7 @@ float max3(float a, float b, float c);
 bool sameSign(float a, float b);
 bool approxEqual(float a, float b);
 
-bool isfinite(float x);
+bool isFinite(float x);
 
 /* quick inverse square root */
 inline float qi_sqrt(float number)
@@ -117,7 +117,7 @@ inline bool approxEqual(float a, float b)
     return (fabsf(a - b) < FLT_EPSILON);
 }
 
-inline bool isfinite(float x)
+inline bool isFinite(float x)
 {
     return (x == x) && (x != INFINITY) && (x != -INFINITY);
 }

--- a/code/sb_halcyon/physics/math/quaternion.h
+++ b/code/sb_halcyon/physics/math/quaternion.h
@@ -165,7 +165,7 @@ float quaternion_dotProduct(const Quaternion *q, const Quaternion *r)
 /* Checks if the quaternion's values are finite. */
 bool quaternion_isFinite(const Quaternion *q)
 {
-    return isfinite(q->x) && isfinite(q->y) && isfinite(q->z) && isfinite(q->w);
+    return isFinite(q->x) && isFinite(q->y) && isFinite(q->z) && isFinite(q->w);
 }
 
 /* Checks if the quaternion is a unit quaternion. */

--- a/code/sb_halcyon/physics/math/vector2.h
+++ b/code/sb_halcyon/physics/math/vector2.h
@@ -114,7 +114,7 @@ bool vector2_isUnit(const Vector2 *vector)
 
 bool vector2_isFinite(const Vector2 *vector)
 {
-    return isfinite(vector->x) && isfinite(vector->y);
+    return isFinite(vector->x) && isFinite(vector->y);
 }
 
 bool vector2_isZero(const Vector2 *vector)

--- a/code/sb_halcyon/physics/math/vector3.h
+++ b/code/sb_halcyon/physics/math/vector3.h
@@ -256,7 +256,7 @@ bool vector3_isUnit(const Vector3 *v)
 
 bool vector3_isFinite(const Vector3 *v)
 {
-    return isfinite(v->x) && isfinite(v->y) && isfinite(v->z);
+    return isFinite(v->x) && isFinite(v->y) && isFinite(v->z);
 }
 
 bool vector3_isZero(const Vector3 *v)

--- a/code/sb_halcyon/ui/ui_colors.h
+++ b/code/sb_halcyon/ui/ui_colors.h
@@ -80,11 +80,11 @@ extern "C"
             0x01009AFF, // N_BLUE
     };
 
-    inline color_t ui_color(int colorIdx);
+    color_t ui_color(int colorIdx);
     uint32_t ui_colorSetAlpha(uint32_t color, uint8_t alpha);
 
     // Creates a color_t from one of the 32-bit packed COLORS.
-    inline color_t ui_color(int colorIdx)
+    color_t ui_color(int colorIdx)
     {
         return color_from_packed32(COLORS[colorIdx]);
     }

--- a/code/sb_holes/ui/ui_colors.h
+++ b/code/sb_holes/ui/ui_colors.h
@@ -80,11 +80,11 @@ extern "C"
             0x01009AFF, // N_BLUE
     };
 
-    inline color_t ui_color(int colorIdx);
+    color_t ui_color(int colorIdx);
     uint32_t ui_colorSetAlpha(uint32_t color, uint8_t alpha);
 
     // Creates a color_t from one of the 32-bit packed COLORS.
-    inline color_t ui_color(int colorIdx)
+    color_t ui_color(int colorIdx)
     {
         return color_from_packed32(COLORS[colorIdx]);
     }

--- a/code/sb_hot/physics/math/math_common.h
+++ b/code/sb_hot/physics/math/math_common.h
@@ -25,7 +25,7 @@ float max3(float a, float b, float c);
 bool sameSign(float a, float b);
 bool approxEqual(float a, float b);
 
-bool isfinite(float x);
+bool isFinite(float x);
 
 /* quick inverse square root */
 inline float qi_sqrt(float number)
@@ -117,7 +117,7 @@ inline bool approxEqual(float a, float b)
     return (fabsf(a - b) < FLT_EPSILON);
 }
 
-inline bool isfinite(float x)
+inline bool isFinite(float x)
 {
     return (x == x) && (x != INFINITY) && (x != -INFINITY);
 }

--- a/code/sb_hot/physics/math/quaternion.h
+++ b/code/sb_hot/physics/math/quaternion.h
@@ -165,7 +165,7 @@ float quaternion_dotProduct(const Quaternion *q, const Quaternion *r)
 /* Checks if the quaternion's values are finite. */
 bool quaternion_isFinite(const Quaternion *q)
 {
-    return isfinite(q->x) && isfinite(q->y) && isfinite(q->z) && isfinite(q->w);
+    return isFinite(q->x) && isFinite(q->y) && isFinite(q->z) && isFinite(q->w);
 }
 
 /* Checks if the quaternion is a unit quaternion. */

--- a/code/sb_hot/physics/math/vector2.h
+++ b/code/sb_hot/physics/math/vector2.h
@@ -114,7 +114,7 @@ bool vector2_isUnit(const Vector2 *vector)
 
 bool vector2_isFinite(const Vector2 *vector)
 {
-    return isfinite(vector->x) && isfinite(vector->y);
+    return isFinite(vector->x) && isFinite(vector->y);
 }
 
 bool vector2_isZero(const Vector2 *vector)

--- a/code/sb_hot/physics/math/vector3.h
+++ b/code/sb_hot/physics/math/vector3.h
@@ -256,7 +256,7 @@ bool vector3_isUnit(const Vector3 *v)
 
 bool vector3_isFinite(const Vector3 *v)
 {
-    return isfinite(v->x) && isfinite(v->y) && isfinite(v->z);
+    return isFinite(v->x) && isFinite(v->y) && isFinite(v->z);
 }
 
 bool vector3_isZero(const Vector3 *v)

--- a/code/sb_hot/ui/ui_colors.h
+++ b/code/sb_hot/ui/ui_colors.h
@@ -80,11 +80,11 @@ extern "C"
             0x01009AFF, // N_BLUE
     };
 
-    inline color_t ui_color(int colorIdx);
+    color_t ui_color(int colorIdx);
     uint32_t ui_colorSetAlpha(uint32_t color, uint8_t alpha);
 
     // Creates a color_t from one of the 32-bit packed COLORS.
-    inline color_t ui_color(int colorIdx)
+    color_t ui_color(int colorIdx)
     {
         return color_from_packed32(COLORS[colorIdx]);
     }

--- a/code/spacewaves/gfx.c
+++ b/code/spacewaves/gfx.c
@@ -201,3 +201,10 @@ void gfx_close(){
     
     if(modelMatFP) free_uncached(modelMatFP);
 }
+
+/* Extern inline instantiations. */
+extern inline bool gfx_pos_within_viewport(float x, float y);
+extern inline bool gfx_pos_within_rect(float x, float y, float xa, float ya, float xb, float yb);
+extern inline float lerp(float a, float b, float t);
+extern inline float fclampr(float x, float min, float max);
+extern inline float fwrap(float x, float min, float max);

--- a/config.h
+++ b/config.h
@@ -26,6 +26,10 @@
     #define MINIGAME_TO_TEST  "examplegame"
 
     // Initialize USB and isViewer logging
-    #define DEBUG 1
+    #if DEBUG == 1
+        #define DEBUG_LOG 1
+    #else
+        #define DEBUG_LOG 0 // Change this one if you just want debugf enabled
+    #endif
 
 #endif

--- a/config.h
+++ b/config.h
@@ -26,7 +26,7 @@
     #define MINIGAME_TO_TEST  "examplegame"
 
     // Initialize USB and isViewer logging
-    #if DEBUG == 1
+    #if defined(DEBUG) && DEBUG == 1
         #define DEBUG_LOG 1
     #else
         #define DEBUG_LOG 0 // Change this one if you just want debugf enabled

--- a/config.h
+++ b/config.h
@@ -25,4 +25,7 @@
     // The current minigame you want to test
     #define MINIGAME_TO_TEST  "examplegame"
 
+    // Initialize USB and isViewer logging
+    #define DEBUG 1
+
 #endif

--- a/main.c
+++ b/main.c
@@ -30,8 +30,7 @@ int main()
     asset_init_compression(2);
     asset_init_compression(3);
     dfs_init(DFS_DEFAULT_LOCATION);
-    debug_init_usblog();
-    debug_init_isviewer();
+
     joypad_init();
     timer_init();
     rdpq_init();

--- a/main.c
+++ b/main.c
@@ -21,7 +21,7 @@ and provides a basic game loop.
 
 int main()
 {
-    #if DEBUG
+    #if DEBUG_LOG == 1
     	debug_init_isviewer();
     	debug_init_usblog();
     #endif


### PR DESCRIPTION
This PR includes the following changes:

1. `make DEBUG=1` will now define for the preprocessor.
2.  add `DEBUG_LOG` define to config.h allow for debug output with defining `DEBUG`
3.  Select minigame changes to accommodate new setup :
 - [SpaceWaves: force non-static inline definitions to be instantiated](https://github.com/n64brew/N64brew-GameJam2024-Template/commit/54b4c58b28e2018f82801067f60c39e1b517101b)
 - [64beats: adjust internal DEBUG definition](https://github.com/n64brew/N64brew-GameJam2024-Template/commit/ccc6c69cd2f5cfc1d0151a979464306bb6530eee)
 - [Furball: adjust internal DEBUG definition](https://github.com/n64brew/N64brew-GameJam2024-Template/commit/95c4356264397456e951d4447e7b167947270059)
 - [don't confuse isFinite with built-in for hexagon games](https://github.com/n64brew/N64brew-GameJam2024-Template/commit/9f316409ea887995bf6a5bf3dc4343e4629539c8) & [Strawberry Byte: don't inline ui_color](https://github.com/n64brew/N64brew-GameJam2024-Template/commit/cd833c2c2707623a1e370dc8509a62699de73cfb)
 - [remove verbose print from Mallard fonts](https://github.com/n64brew/N64brew-GameJam2024-Template/commit/df881fe928383cba6051a514345ea1f06b4404e2)

Note: compiling with `make DEBUG=1` causes crashes in the Strawberry Byte minigames as well as Sneks
![gamejam2024 2024-12-17 12-53-14](https://github.com/user-attachments/assets/a0f33337-ec6f-46ca-866e-836608048793)
![gamejam2024 2024-12-17 12-53-40](https://github.com/user-attachments/assets/5f561f80-23d4-4bef-8831-014806346dae)
