### PR TITLE
Sneks: Mem leak fixes

### DIFF
--- a/code/old_gods/AF_Lib/include/AF_UI.h
+++ b/code/old_gods/AF_Lib/include/AF_UI.h
@@ -16,5 +16,5 @@ void AF_UI_RendererText_Update(AF_CText* _text);
 void AF_UI_RendererSprite_Update(AF_CSprite* _sprite, AF_Time* _time);
 void AF_UI_RendererSprite_Play(AF_CSprite* _sprite, BOOL _isLooping);
 void AF_UI_Renderer_Finish(void);
-void AF_UI_Renderer_Shutdown(void);
+void AF_UI_Renderer_Shutdown(AF_ECS* _ecs);
 void* AF_LoadFont(int _id, const char* _path, uint8_t _color[4]);

--- a/code/old_gods/Scene.c
+++ b/code/old_gods/Scene.c
@@ -1108,6 +1108,8 @@ void Scene_SetupSharks(AppData* _appData){
     // create the shark home
     sharkHomeEntity = AF_ECS_CreateEntity(&_appData->ecs);
     sharkHomeEntity->transform->pos = sharkHunterSpawnPos;
+    sharkHomeEntity->rigidbody->inverseMass = 0.0f;
+    sharkHomeEntity->rigidbody->isKinematic = TRUE;
     // ==== Hunter Shark ====
     // 1 for each player
     for(int i = 0; i < PLAYER_COUNT; ++i){

--- a/code/old_gods/UI_Menu.c
+++ b/code/old_gods/UI_Menu.c
@@ -294,7 +294,9 @@ void UI_Menu_Shutdown(AF_ECS* _ecs){
     wav64_close(&sfx_countdown);
     wav64_close(&sfx_stop);
     wav64_close(&sfx_winner);
+    mixer_ch_stop(0);
     wav64_close(&music_2);
+    wav64_close(&sfx_startButton);
 }
 
 //======= SETUP HELPERS ========
@@ -734,6 +736,7 @@ void UI_Menu_RenderGameOverScreen(AppData* _appData ){
     // only call this once
     // TODO: tidy this up
     if(isDeclaredWinner == FALSE){
+        mixer_ch_stop(0);
         wav64_close(&music_2);
         wav64_play(&sfx_winner, 31);
         //xm64player_stop(&music);
@@ -745,12 +748,14 @@ void UI_Menu_RenderGameOverScreen(AppData* _appData ){
     for(int i = 0; i < PLAYER_COUNT; ++i){
         // detect start button pressed to restart the game
         if(_appData->input.keys[i][A_KEY].pressed == TRUE){
-            gameplayData->gameState = GAME_STATE_GAME_RESTART;
+            gameplayData->gameState = GAME_STATE_GAME_END;
+            core_set_winner(playerWithHighestScore);
+            minigame_end(); 
         }
 
         // Let the game jam template handle the game ending
         if(_appData->input.keys[i][START_KEY].pressed == TRUE){
-            debugf("End minigame\n");
+            //debugf("End minigame\n");
             gameplayData->gameState = GAME_STATE_GAME_END;
             core_set_winner(playerWithHighestScore);
             minigame_end(); 


### PR DESCRIPTION
Edits to address memory leak, and submission requirement requests
Exiting the game to the main menu, memory stabilises to around 210 KiB and doesn't appear to leak anymore.
- Modified AF_Renderer_T3D.c, AF_UI.c, UI_Menu.c to resolve memory leaks (audio, animation data, models)
- Removed console logging during init and shutdown
- Modified App.c to support changes to AF_Renderer_T3D
- Modified Scene to fix a minor shark spawning bug.
- Disabled the hidden debug view 
- Modified UI_Menu to ensure "A" and "Start" button return to menu on game over.
- Modified AF_UI to fix a mem leak with text

Tested on Ares (Windows, OSX), PAL N64 (Everdrive x7)

No other gameplay or visual changes.