### PR TITLE
SpaceWaves: Add compression back to the wav64 assets

### DIFF
--- a/code/spacewaves/bonus.c
+++ b/code/spacewaves/bonus.c
@@ -11,7 +11,7 @@
 #include "gamestatus.h"
 #include "station.h"
 #include "enemycraft.h"
-
+#include "gfx.h"
 #include "bonus.h"
 
 /*#define MAX_BONUSES 10
@@ -77,25 +77,25 @@ void bonus_apply(int bindex, PlyNum playernum, DefenseStation* station, int craf
         case BONUS_POINTS:
             gamestatus.playerscores[playernum] += 1500;
             bonus->enabled = false;
-            wav64_play(&sounds[snd_reload], SFX_CHANNEL_BONUS);
+            afx_wav64_play_wrapper(snd_reload, SFX_CHANNEL_BONUS);
             break;
         case BONUS_UPGRADE:
             if(station) station->arm.powerup = 10.0f;
             if(craft >= 0)   crafts[craft].arm.powerup = 10.0f;
             bonus->enabled = false;
-            wav64_play(&sounds[snd_pickup_shield], SFX_CHANNEL_BONUS);
+            afx_wav64_play_wrapper(snd_pickup_shield, SFX_CHANNEL_BONUS);
             break;
         case BONUS_SHIELD:
             if(station) station->arm.shield = 10.0f;
             if(craft >= 0)   crafts[craft].arm.shield = 10.0f;
             bonus->enabled = false;
-            wav64_play(&sounds[snd_pickup_shield], SFX_CHANNEL_BONUS);
+            afx_wav64_play_wrapper(snd_pickup_shield, SFX_CHANNEL_BONUS);
             break;
         case BONUS_ROCKETS:
             if(station) station->arm.rocketcount += 5;
             if(craft >= 0)   crafts[craft].arm.rocketcount += 3;
             bonus->enabled = false;
-            wav64_play(&sounds[snd_pickup_ammo], SFX_CHANNEL_BONUS);
+            afx_wav64_play_wrapper(snd_pickup_ammo, SFX_CHANNEL_BONUS);
             break;
     }
 }

--- a/code/spacewaves/effects.c
+++ b/code/spacewaves/effects.c
@@ -62,7 +62,7 @@ void effects_add_exp3d(T3DVec3 pos, color_t color){
     effects.exp3d[i].position = pos;
     effects.exp3d[i].color = color;
     effects.exp3d[i].time = 2.0f;
-    wav64_play(&sounds[snd_explosion_blast], SFX_CHANNEL_EXPLOSION);
+    afx_wav64_play_wrapper(snd_explosion_blast, SFX_CHANNEL_EXPLOSION);
 }
 
 void effects_add_exp2d(T3DVec3 pos, color_t color){

--- a/code/spacewaves/enemycraft.c
+++ b/code/spacewaves/enemycraft.c
@@ -171,7 +171,7 @@ void crafts_update(){
 
             if((pressed.a && crafts[c].arm.shield == 10.0f)){
                 crafts[c].arm.shield -= DELTA_TIME;
-                wav64_play(&sounds[snd_use_shield], SFX_CHANNEL_BONUS);
+                afx_wav64_play_wrapper(snd_use_shield, SFX_CHANNEL_BONUS);
                 effects_add_ambientlight(RGBA32(0,0,100,0));
             }
             if(crafts[c].arm.shield < 10.0f) crafts[c].arm.shield -= DELTA_TIME;
@@ -179,7 +179,7 @@ void crafts_update(){
 
             if((pressed.b && crafts[c].arm.powerup == 10.0f)){
                 crafts[c].arm.powerup -= DELTA_TIME;
-                wav64_play(&sounds[snd_use_powerup], SFX_CHANNEL_BONUS);
+                afx_wav64_play_wrapper(snd_use_powerup, SFX_CHANNEL_BONUS);
                 effects_add_ambientlight(RGBA32(0,100,0,0));
             }
             if(crafts[c].arm.powerup < 10.0f) crafts[c].arm.powerup -= DELTA_TIME;
@@ -198,7 +198,7 @@ void crafts_update(){
                 if(held.d_left) crafts[c].arm.asteroids[b].xspeed -= 0.03;
                 crafts[c].arm.asteroids[b].hp = randr(5, 25);
                 crafts[c].arm.asteroidnexttime = CURRENT_TIME + 12.0f;
-                wav64_play(&sounds[snd_hit], SFX_CHANNEL_EFFECTS);
+                afx_wav64_play_wrapper(snd_hit, SFX_CHANNEL_EFFECTS);
                 effects_add_ambientlight(RGBA32(50,50,50,0));
             }
 
@@ -209,7 +209,7 @@ void crafts_update(){
                 crafts[c].arm.rocketnexttime = CURRENT_TIME + 1.0f;
                 crafts[c].arm.rockets[b].hp = 5;
                 crafts[c].arm.rocketcount--;
-                wav64_play(&sounds[snd_shoot_rocket], SFX_CHANNEL_ROCKET);
+                afx_wav64_play_wrapper(snd_shoot_rocket, SFX_CHANNEL_ROCKET);
                 effects_add_rumble(crafts[c].currentplayerport, 0.45f);
                 effects_add_ambientlight(RGBA32(50,50,25,0));
             }

--- a/code/spacewaves/gfx.c
+++ b/code/spacewaves/gfx.c
@@ -116,6 +116,8 @@ const char *sound_path[SOUND_COUNT] = {
     "rom://spacewaves/use_shield.wav64"
 };
 
+int sound_cur_channels[SOUND_COUNT] = {0};
+
 void gfx_load(){
     font = rdpq_font_load("rom://spacewaves/JupiteroidBoldItalic.font64");
     font2 = rdpq_font_load("rom://spacewaves/Jupiteroid.font64");
@@ -201,6 +203,19 @@ void gfx_close(){
     
     if(modelMatFP) free_uncached(modelMatFP);
 
+}
+
+// workaround for a bug with vadpcm
+void afx_wav64_play_wrapper(int soundindex, int ch){
+    mixer_ch_stop(ch);
+    mixer_ch_stop(ch+1); // stereo
+    int ch_pl = sound_cur_channels[soundindex];
+    if(ch_pl > 0){
+        mixer_ch_stop(ch_pl);
+        mixer_ch_stop(ch_pl+1); // stereo
+    }
+    wav64_play(&sounds[soundindex], ch);
+    sound_cur_channels[soundindex] = ch;
 }
 
 /* Extern inline instantiations. */

--- a/code/spacewaves/gfx.h
+++ b/code/spacewaves/gfx.h
@@ -44,6 +44,7 @@ extern const char *model_path[MODEL_COUNT];
 
 extern wav64_t sounds[SOUND_COUNT];
 extern const char *sound_path[SOUND_COUNT];
+extern int sound_cur_channels[SOUND_COUNT];
 
 extern xm64player_t xmplayer;
 extern bool xmplayeropen;
@@ -152,5 +153,6 @@ inline float fwrap(float x, float min, float max) {
     return (x >= 0 ? min : max) + fmod(x, max - min);
 }
 
+void afx_wav64_play_wrapper(int soundindex, int ch);
 
 #endif

--- a/code/spacewaves/spacewaves.c
+++ b/code/spacewaves/spacewaves.c
@@ -105,7 +105,7 @@ int main()
       if(btn.start && (gamestatus.state == GAMESTATE_PLAY || gamestatus.state == GAMESTATE_PAUSED)){
         gamestatus.paused = !gamestatus.paused;
         gamestatus.state = gamestatus.paused? GAMESTATE_PAUSED : GAMESTATE_PLAY;
-        wav64_play(&sounds[snd_button_click2], SFX_CHANNEL_EFFECTS);
+        afx_wav64_play_wrapper(snd_button_click2, SFX_CHANNEL_EFFECTS);
       }
       if(btn.start && gamestatus.state == GAMESTATE_GETREADY){
         gamestatus.paused = true;
@@ -116,7 +116,7 @@ int main()
           xm64player_open(&xmplayer, music_path[currentmusicindex]);
         xm64player_play(&xmplayer, SFX_CHANNEL_MUSIC);
         xm64player_set_loop(&xmplayer, true);
-        wav64_play(&sounds[snd_button_click1], SFX_CHANNEL_EFFECTS);
+        afx_wav64_play_wrapper(snd_button_click1, SFX_CHANNEL_EFFECTS);
         xmplayeropen = true;
       }
     }
@@ -124,12 +124,12 @@ int main()
       gamestatus.state = GAMESTATE_PLAY;
       gamestatus.paused = false;
       gamestatus.statetime = 180.0f;
-      wav64_play(&sounds[snd_button_click3], SFX_CHANNEL_BONUS);
+      afx_wav64_play_wrapper(snd_button_click3, SFX_CHANNEL_BONUS);
     }
     if(gamestatus.state == GAMESTATE_COUNTDOWN){
       int newcountseconds = (int)gamestatus.statetime;
       if (newcountseconds != countdownseconds){
-          wav64_play(&sounds[snd_button_click3], SFX_CHANNEL_BONUS);
+          afx_wav64_play_wrapper(snd_button_click3, SFX_CHANNEL_BONUS);
           countdownseconds = newcountseconds;
       }
     }

--- a/code/spacewaves/spacewaves.mk
+++ b/code/spacewaves/spacewaves.mk
@@ -72,4 +72,4 @@ $(FILESYSTEM_DIR)/spacewaves/%.m1v: $(ASSETS_DIR)/spacewaves/%.m1v
 filesystem/spacewaves/machinegun_new_01.i4.sprite: MKSPRITE_FLAGS=--format I8
 filesystem/spacewaves/machinegun_new_02.i4.sprite: MKSPRITE_FLAGS=--format I8
 
-$(FILESYSTEM_DIR)/spacewaves/%.wav64: AUDIOCONV_FLAGS= --wav-compress 0
+$(FILESYSTEM_DIR)/spacewaves/%.wav64: AUDIOCONV_FLAGS= --wav-compress 1

--- a/code/spacewaves/station.c
+++ b/code/spacewaves/station.c
@@ -32,7 +32,7 @@ void station_init(PlyNum player){
     station.yaw = 0;
     station.arm.bulletnexttime = CURRENT_TIME + 0.5f;
     wav64_set_loop(&sounds[snd_machinery], true);
-    wav64_play(&sounds[snd_machinery], SFX_CHANNEL_STATION);
+    afx_wav64_play_wrapper(snd_machinery, SFX_CHANNEL_STATION);
     mixer_ch_set_vol(SFX_CHANNEL_STATION, 0.0f, 0.0f);
 }
 
@@ -84,7 +84,7 @@ void station_update(){
         if(station.arm.powerup > 0.0f && station.arm.powerup < 10.0f) 
             station.arm.bulletnexttime = CURRENT_TIME + 0.2f;
         station.arm.machinegunoffset = -150;
-        wav64_play(&sounds[snd_shoot], SFX_CHANNEL_MACHINEGUN);
+        afx_wav64_play_wrapper(snd_shoot, SFX_CHANNEL_MACHINEGUN);
         effects_add_rumble(station.currentplayerport, 0.1f);
         effects_add_ambientlight(RGBA32(0,25,50,0));
     }
@@ -98,7 +98,7 @@ void station_update(){
             station.arm.rocketnexttime = CURRENT_TIME + 1.0f;
         station.arm.rocketcount--;
         station.arm.rocketgunoffset = -150;
-        wav64_play(&sounds[snd_shoot_rocket], SFX_CHANNEL_ROCKET);
+        afx_wav64_play_wrapper(snd_shoot_rocket, SFX_CHANNEL_ROCKET);
         effects_add_rumble(station.currentplayerport, 0.25f);
         effects_add_ambientlight(RGBA32(50,50,25,0));
     }
@@ -110,7 +110,7 @@ void station_update(){
 
     if((pressed.a && station.arm.shield == 10.0f)){
         station.arm.shield -= DELTA_TIME;
-        wav64_play(&sounds[snd_use_shield], SFX_CHANNEL_BONUS);
+        afx_wav64_play_wrapper(snd_use_shield, SFX_CHANNEL_BONUS);
         effects_add_ambientlight(RGBA32(0,0,100,0));
     }
     if(station.arm.shield < 10.0f)
@@ -120,7 +120,7 @@ void station_update(){
 
     if((pressed.b && station.arm.powerup == 10.0f)){
         station.arm.powerup -= DELTA_TIME;
-        wav64_play(&sounds[snd_use_powerup], SFX_CHANNEL_BONUS);
+        afx_wav64_play_wrapper(snd_use_powerup, SFX_CHANNEL_BONUS);
         effects_add_ambientlight(RGBA32(0,100,0,0));
     }
     if(station.arm.powerup < 10.0f)
@@ -165,7 +165,7 @@ void station_update(){
                         gamestatus.playerscores[station.currentplayer] += 10 * 50;
                     }
                     station.arm.bullets[b].enabled = false;
-                    wav64_play(&sounds[snd_hit], SFX_CHANNEL_HIT);
+                    afx_wav64_play_wrapper(snd_hit, SFX_CHANNEL_HIT);
                     effects_add_exp2d(gfx_worldpos_from_polar(
                             station.arm.bullets[b].polarpos.v[0],
                             station.arm.bullets[b].polarpos.v[1],
@@ -178,7 +178,7 @@ void station_update(){
                         gamestatus.playerscores[station.currentplayer] += 8000;
                     }
                     station.arm.rockets[b].enabled = false;
-                    wav64_play(&sounds[snd_hit], SFX_CHANNEL_HIT);
+                    afx_wav64_play_wrapper(snd_hit, SFX_CHANNEL_HIT);
                     effects_add_ambientlight(RGBA32(50,50,25,0));
                 }
             }
@@ -195,7 +195,7 @@ void station_update(){
                     crafts[c].arm.asteroids[p].hp -= 10;
                     gamestatus.playerscores[station.currentplayer] += 10 * 20;
                     station.arm.bullets[b].enabled = false;
-                    wav64_play(&sounds[snd_hit], SFX_CHANNEL_EFFECTS);
+                    afx_wav64_play_wrapper(snd_hit, SFX_CHANNEL_EFFECTS);
                     effects_add_exp2d(gfx_worldpos_from_polar(
                             station.arm.bullets[b].polarpos.v[0],
                             station.arm.bullets[b].polarpos.v[1],
@@ -206,7 +206,7 @@ void station_update(){
                     crafts[c].arm.asteroids[p].hp -= 100;
                     gamestatus.playerscores[station.currentplayer] += 1000;
                     station.arm.rockets[b].enabled = false;
-                    wav64_play(&sounds[snd_hit], SFX_CHANNEL_EFFECTS);
+                    afx_wav64_play_wrapper(snd_hit, SFX_CHANNEL_EFFECTS);
                     effects_add_rumble(crafts[c].currentplayerport, 1.25f);
                     effects_add_shake(1.25f);
                 }
@@ -220,7 +220,7 @@ void station_update(){
                     crafts[c].arm.rockets[p].hp -= 10;
                     gamestatus.playerscores[station.currentplayer] += 10 * 50;
                     station.arm.bullets[b].enabled = false;
-                    wav64_play(&sounds[snd_hit], SFX_CHANNEL_EFFECTS);
+                    afx_wav64_play_wrapper(snd_hit, SFX_CHANNEL_EFFECTS);
                     effects_add_rumble(crafts[c].currentplayerport, 0.25f);
                 }
             }


### PR DESCRIPTION
There's now a workaround for the VADPCM related crashes and the game files now properly fit under 2MB