### PR TITLE
Fix for broken/invisible text

### DIFF
--- a/code/snowmen/DecorationSpawner.c
+++ b/code/snowmen/DecorationSpawner.c
@@ -81,38 +81,38 @@ void SpawnerInit(struct DecorationSpawnerStruct* decorationSpawner, enum EDecora
     //decorationSpawner->decorationType = EDT_Decoration1;
 
         //////////////////////////////////////
-    color_t color = color_from_packed32(0x000000<<8);
+    color_t color = RGBA32(0, 0, 0, 255);// color_from_packed32(0x000000ff);
 
     switch (decorationSpawner->decorations[0].decorationType)
     {
     case EDT_Decoration1:
         decorationSpawner->spawnerActor.model = t3d_model_load("rom:/snowmen/spawner_stones.t3dm");
-        color = color_from_packed32(0x4a4a4a<<8);
+        color = RGBA32(74, 74, 74, 255);//color_from_packed32(0x4a4a4aff);
         break;
     case EDT_Decoration2:
         decorationSpawner->spawnerActor.model = t3d_model_load("rom:/snowmen/spawner_carrot.t3dm");
-        color = color_from_packed32(0xdb741a<<8);
+        color = RGBA32(219, 116, 26, 255);//color_from_packed32(0xdb741aff);
         break;
     case EDT_Decoration3:
         decorationSpawner->spawnerActor.model = t3d_model_load("rom:/snowmen/spawner_mitt.t3dm");
-        color = color_from_packed32(0xc75292<<8);
+        color = RGBA32(199, 82, 146, 255);//color_from_packed32(0xc75292ff);
         break;
     case EDT_Decoration4:
         decorationSpawner->spawnerActor.model = t3d_model_load("rom:/snowmen/spawner_hat.t3dm");
-        color = color_from_packed32(0xffffff<<8);
+        color = RGBA32(255, 255, 255, 255);//color_from_packed32(0xffffffff);
         break;
     case EDT_Decoration5:
         decorationSpawner->spawnerActor.model = t3d_model_load("rom:/snowmen/spawner_scarf.t3dm");
-        color = color_from_packed32(0xb02e20<<8);
+        color = RGBA32(176, 46, 32, 255);//color_from_packed32(0xb02e20ff);
         break;
     case EDT_Decoration6:
         decorationSpawner->spawnerActor.model = t3d_model_load("rom:/snowmen/spawner_sticks.t3dm");
-        color = color_from_packed32(0x704022<<8);
+        color = RGBA32(112, 64, 34, 255);//color_from_packed32(0x704022ff);
         break;
     
     default:
         decorationSpawner->spawnerActor.model = t3d_model_load("rom:/snowmen/spawner_stones.t3dm");
-        color = color_from_packed32(0x4a4a4a<<8);
+        color = RGBA32(74, 74, 74, 255);//color_from_packed32(0x4a4a4aff);
         break;
     }
 

--- a/code/snowmen/mygamemain.c
+++ b/code/snowmen/mygamemain.c
@@ -1009,8 +1009,8 @@ void SetSnowballSpawnLocations(SpawnLocation locations[6])
 
 void player_draw_billboard(PlayerStruct* playerStruct)
 {
-  rdpq_sync_pipe();// Hardware crashes otherwise
-  rdpq_sync_tile(); // Hardware crashes otherwise
+  //rdpq_sync_pipe();// Hardware crashes otherwise
+  //rdpq_sync_tile(); // Hardware crashes otherwise
 
   T3DVec3 billboardPos = (T3DVec3){{
     playerStruct->PlayerActor.Position.v[0],
@@ -1024,8 +1024,8 @@ void player_draw_billboard(PlayerStruct* playerStruct)
   int x = floorf(billboardScreenPos.v[0]);
   int y = floorf(billboardScreenPos.v[1]);
 
-  rdpq_sync_pipe(); // Hardware crashes otherwise
-  rdpq_sync_tile(); // Hardware crashes otherwise
+  //rdpq_sync_pipe(); // Hardware crashes otherwise
+  //rdpq_sync_tile(); // Hardware crashes otherwise
 
     rdpq_text_printf(&(rdpq_textparms_t){ .style_id = playerStruct->playerId }, FONT_BILLBOARD, x-5, y-16, "P%d", playerStruct->playerId+1);
     //rdpq_text_printf(NULL, FONT_BILLBOARD, x-5, y-16, "P%d", playerStruct->playerId+1);
@@ -1034,8 +1034,8 @@ void player_draw_billboard(PlayerStruct* playerStruct)
 
 void draw_billboard_generic(T3DVec3* billboardPos, char* string, float yOffset)
 {
-  rdpq_sync_pipe(); // Hardware crashes otherwise
-  rdpq_sync_tile(); // Hardware crashes otherwise
+  //rdpq_sync_pipe(); // Hardware crashes otherwise
+  //rdpq_sync_tile(); // Hardware crashes otherwise
 
   /*T3DVec3 billboardPos = (T3DVec3){{
     playerStruct->PlayerActor.Position.v[0],
@@ -1049,14 +1049,13 @@ void draw_billboard_generic(T3DVec3* billboardPos, char* string, float yOffset)
   int x = floorf(billboardScreenPos.v[0]);
   int y = floorf(billboardScreenPos.v[1] + yOffset);
 
-  rdpq_sync_pipe(); // Hardware crashes otherwise
-  rdpq_sync_tile(); // Hardware crashes otherwise
+  //rdpq_sync_pipe(); // Hardware crashes otherwise
+  //rdpq_sync_tile(); // Hardware crashes otherwise
     //char string1[32];
   //snprintf(string1, sizeof(string1), "%d potatoe", -1);
 
     rdpq_text_printf(&(rdpq_textparms_t){ .style_id = 4 }, FONT_BILLBOARD, x-5, y-16, "%s", string);
     //rdpq_text_printf(NULL, FONT_BILLBOARD, x-5, y-16, "P%d", playerStruct->playerId+1);
-
 }
 
 void spawn_temp_billboard(T3DVec3* billboardPos, char* string, bool moveUp, float deltaTime)
@@ -1123,11 +1122,17 @@ void minigame_init()
     rdpq_text_register_font(FONT_TEXT, font);
     rdpq_font_style(font, 0, &(rdpq_fontstyle_t){.color = color_from_packed32(TEXT_COLOR) });
 
-    const color_t colors[] = {
+    /*const color_t colors[] = {
         color_from_packed32(0xFF0000<<8),
         color_from_packed32(0x0000FF<<8),
         color_from_packed32(0xFFFF00<<8),
         color_from_packed32(0x00FF00<<8),
+    };*/
+    const color_t colors[] = {
+        PLAYERCOLOR_1,
+        RGBA32(61, 90, 255, 255),
+        PLAYERCOLOR_4,
+        RGBA32(0, 255, 0, 255),
     };
 
     fontBillboard = rdpq_font_load("rom:/squarewave.font64");
@@ -1136,7 +1141,11 @@ void minigame_init()
     {
         rdpq_font_style(fontBillboard, i, &(rdpq_fontstyle_t){ .color = colors[i] });
     }
-    rdpq_font_style(fontBillboard, 4, &(rdpq_fontstyle_t){ .color = color_from_packed32(0xFFFFFF<<8) });
+    /*rdpq_font_style(fontBillboard, 0, &(rdpq_fontstyle_t){ .color = PLAYERCOLOR_1 });
+    rdpq_font_style(fontBillboard, 1, &(rdpq_fontstyle_t){ .color = PLAYERCOLOR_2 });
+    rdpq_font_style(fontBillboard, 2, &(rdpq_fontstyle_t){ .color = PLAYERCOLOR_3 });
+    rdpq_font_style(fontBillboard, 3, &(rdpq_fontstyle_t){ .color = PLAYERCOLOR_4 });*/
+    rdpq_font_style(fontBillboard, 4, &(rdpq_fontstyle_t){ .color = RGBA32(255, 255, 255, 255) });
 
     
 
@@ -1356,7 +1365,7 @@ void minigame_init()
     EnvActor.collisionModelPath = "rom:/snowmen/SnowyMapTest6_4_Collision.col";
     rspq_block_begin();
         t3d_matrix_push(EnvActor.TransformFP);
-        rdpq_set_prim_color(color_from_packed32(0x17752c));
+        rdpq_set_prim_color(RGBA32(23, 117, 44, 255));
         t3d_model_draw(EnvActor.model);
         t3d_matrix_pop(1);
     EnvActor.dpl = rspq_block_end();
@@ -1414,10 +1423,10 @@ T3DModel *treeModel;*/
     wav64_open(&sfx_stop, "rom:/core/Stop.wav64");
     wav64_open(&sfx_winner, "rom:/core/Winner.wav64");
     //xm64player_open(&music, "rom:/snake3d/bottled_bubbles.xm64");
-     xm64player_open(&music, "rom:/snowmen/christmas_day.xm64");
+    xm64player_open(&music, "rom:/snowmen/christmas_day.xm64");
     //xm64player_play(&music, 0);
-    rdpq_sync_pipe(); // Hardware crashes otherwise
-        rdpq_sync_tile(); 
+    //rdpq_sync_pipe(); // Hardware crashes otherwise
+        //rdpq_sync_tile(); 
 }
 
 void draw_loop(bool showText, float deltaTime)
@@ -1425,6 +1434,9 @@ void draw_loop(bool showText, float deltaTime)
     //rdpq_mode_antialias(AA_STANDARD);
     if (TitleScreen)
     {
+          //rdpq_sync_pipe(); // Hardware crashes otherwise
+            //rdpq_sync_tile(); // Hardware crashes otherwise
+        syncPoint = rspq_syncpoint_new();
         t3d_mat4_from_srt_euler(&snowballs[0].pickupActor.Transform,
             (float[3]){.5f, .5f, .5f}, 
             (float[3]){0.f, 0.f, 0.f},
@@ -1454,24 +1466,25 @@ void draw_loop(bool showText, float deltaTime)
           t3d_mat4_to_fixed(snowmen[0].HeadTransformFP,  &snowmen[0].snowmanActor.Transform);
             t3d_mat4_to_fixed(snowmen[0].TorsoTransformFP,  &snowmen[0].snowmanActor.Transform);
                 t3d_mat4_to_fixed(snowmen[0].StickTransformFP,  &snowmen[0].snowmanActor.Transform);
-
+          //rdpq_sync_pipe(); // Hardware crashes otherwise
+        //rdpq_sync_tile(); // Hardware crashes otherwise
 
         rspq_block_run(snowballs[0].pickupActor.dpl);
         rspq_block_run(spawners[3].spawnerActor.dpl);
         SnowmanDrawAll(&snowmen[0]);
 
-        rdpq_sync_pipe(); // Hardware crashes otherwise
-        rdpq_sync_tile(); // Hardware crashes otherwise
+        //rdpq_sync_pipe(); // Hardware crashes otherwise
+        //rdpq_sync_tile(); // Hardware crashes otherwise
 
         //rdpq_text_printf(&(rdpq_textparms_t){ .style_id = 4 }, 2, 10, 10,"%.2f", display_get_fps());
-        rdpq_text_printf(&(rdpq_textparms_t){ .style_id = 4 }, 2, 20, display_get_height()*.10f,"Grab decorations and Snowballs");// decorations and Snowballs \nwith the A Button!");
+        rdpq_text_printf(&(rdpq_textparms_t){ .style_id = 4}, 2, 20, display_get_height()*.10f,"Grab decorations and Snowballs");// decorations and Snowballs \nwith the A Button!");
             //rdpq_text_printf(&(rdpq_textparms_t){ .style_id = 4 }, 2, 45, display_get_height()*.10f," decorations and Snowballs");//A Button!");
-                rdpq_text_printf(&(rdpq_textparms_t){ .style_id = 4 }, 2, 20, display_get_height()*.17f,"with the ");//A Button!");
+                rdpq_text_printf(&(rdpq_textparms_t){ .style_id = 4}, 2, 20, display_get_height()*.17f,"with the ");//A Button!");
                     rdpq_text_printf(&(rdpq_textparms_t){ .style_id = 1 }, 2, 70, display_get_height()*.17f,"A Button!");
         rdpq_text_printf(&(rdpq_textparms_t){ .style_id = 4 }, 2, 20, display_get_height()*.25f,"Then");//, bring them back to your \nsmiley face base!");
-            rdpq_text_printf(&(rdpq_textparms_t){ .style_id = 2 }, 2, 50, display_get_height()*.25f,"bring them back");// to your \nsmiley face base!");
+            rdpq_text_printf(&(rdpq_textparms_t){ .style_id = 1 }, 2, 50, display_get_height()*.25f,"bring them back");// to your \nsmiley face base!");
                 rdpq_text_printf(&(rdpq_textparms_t){ .style_id = 4 }, 2, 140, display_get_height()*.25f,"to your");// \nsmiley face base!");
-                    rdpq_text_printf(&(rdpq_textparms_t){ .style_id = 2 }, 2, 20, display_get_height()*.32f,"smiley face base!");
+                    rdpq_text_printf(&(rdpq_textparms_t){ .style_id = 1 }, 2, 20, display_get_height()*.32f,"smiley face base!");
         rdpq_text_printf(&(rdpq_textparms_t){ .style_id = 4 }, 2, 20, display_get_height()*.45f,"Snowballs = 2 points");
         rdpq_text_printf(&(rdpq_textparms_t){ .style_id = 4 }, 2, 20, display_get_height()*.55f,"Decorations = 1 point");
         rdpq_text_printf(&(rdpq_textparms_t){ .style_id = 3 }, 2, 20, display_get_height()*.68f,"Stun");// opponents with the B button \nto steal what they're holding!");
@@ -1561,7 +1574,7 @@ void draw_loop(bool showText, float deltaTime)
 
     if (showText)
     {
-        syncPoint = rspq_syncpoint_new();
+        //syncPoint = rspq_syncpoint_new();
 
 
         for(int i = 0; i < 4; i++)
@@ -1586,8 +1599,8 @@ void draw_loop(bool showText, float deltaTime)
                     snowmen[i].snowmanActor.BillboardPosition = snowmen[i].snowmanActor.Position;
                 }
             }
-              rdpq_sync_pipe(); // Hardware crashes otherwise
-                rdpq_sync_tile(); // Hardware crashes otherwise
+              //rdpq_sync_pipe(); // Hardware crashes otherwise
+                //rdpq_sync_tile(); // Hardware crashes otherwise
         }
 
         
@@ -1606,8 +1619,8 @@ void draw_loop(bool showText, float deltaTime)
                     spawners[i].spawnerActor.BillboardPosition = spawners[i].spawnerActor.Position;
                 }
             }
-              rdpq_sync_pipe(); // Hardware crashes otherwise
-  rdpq_sync_tile(); // Hardware crashes otherwise
+              //rdpq_sync_pipe(); // Hardware crashes otherwise
+  //rdpq_sync_tile(); // Hardware crashes otherwise
         }
 
 
@@ -1615,8 +1628,8 @@ void draw_loop(bool showText, float deltaTime)
         snprintf(string1, sizeof(string1), "+%d", 2);
         draw_billboard_generic(&players[0].PlayerActor.Position, string1);*/
 
-        rdpq_sync_pipe(); // Hardware crashes otherwise
-        rdpq_sync_tile(); // Hardware crashes otherwise
+        //rdpq_sync_pipe(); // Hardware crashes otherwise
+        //rdpq_sync_tile(); // Hardware crashes otherwise
 
 
         if (TESTING) rdpq_text_printf(&(rdpq_textparms_t){ .style_id = 4 }, 2, 10, 10,"%.2f", display_get_fps());
@@ -2335,11 +2348,13 @@ void minigame_loop(float deltatime)
             t3d_light_set_ambient(colorAmbient);
             if (TitleScreen || EndDelay <= 0)
             {
-                t3d_screen_clear_color(color_from_packed32(0x9ab3ed<<8));
+                t3d_screen_clear_color(RGBA32(154, 179, 237, 255));
+                //t3d_screen_clear_color(color_from_packed32(0x9ab3ed<<8));
             }
             else
             {
-                t3d_screen_clear_color(color_from_packed32(0xdedede<<8));
+                t3d_screen_clear_color(RGBA32(222, 222, 222, 255));
+                //t3d_screen_clear_color(color_from_packed32(0xdedede<<8));
             }
             t3d_screen_clear_depth();
             uint8_t colorDir[4]     = {0xFF, 0xAA, 0xAA, 0xFF};
@@ -2359,8 +2374,8 @@ void minigame_loop(float deltatime)
         CameraLoop(&camera4, &players[3].PlayerActor, &viewports[3]);
         draw_loop(false, deltatime);
 
-        rdpq_sync_pipe(); // Hardware crashes otherwise
-        rdpq_sync_tile(); // Hardware crashes otherwise
+        //rdpq_sync_pipe(); // Hardware crashes otherwise
+        //rdpq_sync_tile(); // Hardware crashes otherwise
         rdpq_text_printf(NULL, 2, display_get_width()/2 + 10, display_get_height()/2 + 10,"%.2f", display_get_fps());
         //rdpq_text_printf(NULL, 2, display_get_width()/2 + 10, display_get_height()/2 + 20,"%.2f", dist);
         //rdpq_text_printf(NULL, 2, 10, 20,"%ld", core_get_playercount());

--- a/code/snowmen/pickup.c
+++ b/code/snowmen/pickup.c
@@ -491,7 +491,7 @@ void PickupSetType(struct PickupStruct* pickupStruct, enum EDecorationType decor
 {
     pickupStruct->decorationType = decorationType;
 
-    color_t color = color_from_packed32(0x000000<<8);
+    color_t color = color_from_packed32(0x000000ff);
 
     /*if (pickupStruct->pickupActor.model != NULL)
     {
@@ -504,27 +504,27 @@ void PickupSetType(struct PickupStruct* pickupStruct, enum EDecorationType decor
             {
             case EDT_Decoration1:
                 pickupStruct->pickupActor.model = t3d_model_load("rom:/snowmen/deco_rock_1.t3dm");
-                color = color_from_packed32(0x4a4a4a<<8);
+                color = color_from_packed32(0x4a4a4aff);
                 break;
             case EDT_Decoration2:
                 pickupStruct->pickupActor.model = t3d_model_load("rom:/snowmen/deco_carrot.t3dm");
-                color = color_from_packed32(0xdb741a<<8);
+                color = color_from_packed32(0xdb741aff);
                 break;
             case EDT_Decoration3:
                 pickupStruct->pickupActor.model = t3d_model_load("rom:/snowmen/deco_mitt.t3dm");
-                color = color_from_packed32(0xc75292<<8);
+                color = color_from_packed32(0xc75292ff);
                 break;
             case EDT_Decoration4:
                 pickupStruct->pickupActor.model = t3d_model_load("rom:/snowmen/deco_hat.t3dm");
-                color = color_from_packed32(0xffffff<<8);
+                color = color_from_packed32(0xffffffff);
                 break;
             case EDT_Decoration5:
                 pickupStruct->pickupActor.model = t3d_model_load("rom:/snowmen/deco_scarf.t3dm");
-                color = color_from_packed32(0xb02e20<<8);
+                color = color_from_packed32(0xb02e20ff);
                 break;
             case EDT_Decoration6:
                 pickupStruct->pickupActor.model = t3d_model_load("rom:/snowmen/deco_stick.t3dm");
-                color = color_from_packed32(0x704022<<8);
+                color = color_from_packed32(0x704022ff);
                 break;
             
             default:
@@ -538,7 +538,7 @@ void PickupSetType(struct PickupStruct* pickupStruct, enum EDecorationType decor
 
         rspq_block_begin();
             t3d_matrix_push(pickupStruct->pickupActor.TransformFP);
-            rdpq_set_prim_color(color_from_packed32(0xfca9dd<<8));
+            rdpq_set_prim_color(color_from_packed32(0xfca9ddff));
             t3d_model_draw(pickupStruct->pickupActor.model);// Draw Static Mesh
         t3d_matrix_pop(1);// must also pop it when done
         pickupStruct->dplAltSnowball = rspq_block_end();

--- a/code/snowmen/snowman.c
+++ b/code/snowmen/snowman.c
@@ -145,7 +145,7 @@ void SnowmanInit(struct SnowmanStruct* snowmanStruct, enum EPlayerId newOwner)
         break;
 
         default:
-        SnowmanColour = color_from_packed32(0x000000<<8);
+        SnowmanColour = color_from_packed32(0x000000ff);
         break;
     }
     
@@ -158,7 +158,7 @@ void SnowmanInit(struct SnowmanStruct* snowmanStruct, enum EPlayerId newOwner)
     snowmanStruct->dpls[SNOWBALL0] = rspq_block_end();
     rspq_block_begin();
     t3d_matrix_push(snowmanStruct->HeadTransformFP);
-        rdpq_set_prim_color(color_from_packed32(0xdb741a<<8));
+        rdpq_set_prim_color(color_from_packed32(0xdb741aff));
         t3d_model_draw(snowmanStruct->models[CARROT]);
     t3d_matrix_pop(1);
     snowmanStruct->dpls[CARROT] = rspq_block_end();
@@ -208,7 +208,7 @@ void SnowmanInit(struct SnowmanStruct* snowmanStruct, enum EPlayerId newOwner)
     snowmanStruct->dpls[MITT] = rspq_block_end();
     rspq_block_begin();
     t3d_matrix_push(snowmanStruct->StickTransformFP);
-        rdpq_set_prim_color(color_from_packed32(0x704022<<8));
+        rdpq_set_prim_color(color_from_packed32(0x704022ff));
         t3d_model_draw(snowmanStruct->models[STICK]);
     t3d_matrix_pop(1);
     snowmanStruct->dpls[STICK] = rspq_block_end();

--- a/code/snowmen/snowman.h
+++ b/code/snowmen/snowman.h
@@ -22,10 +22,10 @@
 #define STONESTORSO      9
 #define STONESBOTTOM     10
 
-#define RED              color_from_packed32(0xFF0000<<8)
-#define BLUE             color_from_packed32(0x0000FF<<8)
-#define YELLOW           color_from_packed32(0xFFFF00<<8)
-#define GREEN            color_from_packed32(0x00FF00<<8)
+#define RED              color_from_packed32(0xFF0000ff)
+#define BLUE             color_from_packed32(0x0000FFff)
+#define YELLOW           color_from_packed32(0xFFFF00ff)
+#define GREEN            color_from_packed32(0x00FF00ff)
 
 
 enum ESnowmanLevel {


### PR DESCRIPTION
The way my colour was formatted for text was incorrect, as it didn't write an alpha value. It wasn't an issue before, but since fonts now support alpha channels it bug appeared.
I also removed the rdpq syncs as they aren't needed anymore.